### PR TITLE
Altera estado de render do Videomatik de "render" para "rendering"

### DIFF
--- a/eventos/functions/add-videomatik.protected.js
+++ b/eventos/functions/add-videomatik.protected.js
@@ -20,7 +20,7 @@ const md5 = require('md5');
 
 const VIDEOMATIK_ESTADOS_TRAVAR = [
   'new',
-  'render'
+  'rendering'
 ]
 
 // parâmetros: imagem, from

--- a/eventos/functions/videomatik-webhook.js
+++ b/eventos/functions/videomatik-webhook.js
@@ -37,7 +37,7 @@ exports.handler = async function(context, event, callback) {
     console.log('resultado participante', participante);
 
     switch(state) {
-        case 'render':
+        case 'rendering':
             await client.messages.create({
                 from: `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER_TDC}`,
                 to: `whatsapp:${participante.phoneNumber}`,


### PR DESCRIPTION
Fala @luisleao ! 

O @brorlandi deve ter comentado de um ajuste que estávamos fazendo do estado de `render` para `rendering`, certo?

Estava vendo um pouco do código do chatbot para os eventos, acredito que alterando nestes dois pontos seria o suficiente para ficar tudo certo. Pode fazer um review para mim se está tudo certo?

*Ainda não está enviando `rendering` do nosso lado, mas assim que estiver trocado do nosso lado posso dar um aviso.

